### PR TITLE
Add MVP filtering controls for events

### DIFF
--- a/public/events.js
+++ b/public/events.js
@@ -1,0 +1,306 @@
+const csvUrl = "https://docs.google.com/spreadsheets/d/e/2PACX-1vQs9es85_FKgTgEVkNBb2NqcINPWyN6ofxMUYbrLeuFiTD2R49-37t-3TyahkR_PYsgs4wBSknAol0R/pub?gid=0&single=true&output=csv";
+let allEvents = [];
+let filteredEvents = [];
+let map;
+const filters = {
+  search: "",
+  category: "all",
+  price: "all"
+};
+
+// ---------- МОДАЛКА С АНИМАЦИЕЙ + КНОПКОЙ ----------
+function openDetailCard(event) {
+  const modal = document.getElementById("event-detail");
+  document.getElementById("detail-title").textContent = event.Name || "";
+  document.getElementById("detail-date").textContent = event.Date || "";
+  document.getElementById("detail-time").textContent = event.Time || "";
+  document.getElementById("detail-place").textContent = event.Place || "";
+  document.getElementById("detail-category").textContent = event.Category || "";
+  document.getElementById("detail-cost").textContent = event.Cost || "";
+  document.getElementById("detail-desc").textContent = event.Description || "";
+
+  const detailImage = document.getElementById("detail-img");
+  detailImage.src = event.Media || "https://via.placeholder.com/600x400?text=No+Image";
+  detailImage.alt = event.Name || "";
+
+  const mapBtn = document.getElementById("detail-map-btn");
+  mapBtn.onclick = async () => {
+    closeDetailCard();
+    document.getElementById("map-modal").style.display = "flex";
+    const source = filteredEvents.length ? filteredEvents : allEvents;
+    await initMap(source);
+    const coords = await getEventCoordinates(event);
+    if (coords && map) {
+      map.setView([coords.lat, coords.lon], 15, { animate: true });
+      L.popup()
+        .setLatLng([coords.lat, coords.lon])
+        .setContent(`<b>${event.Name}</b><br>${event.Place}<br>${event.Date || ""} ${event.Time || ""}`)
+        .openOn(map);
+    }
+    setTimeout(() => map.invalidateSize(), 300);
+  };
+
+  modal.style.display = "flex";
+  requestAnimationFrame(() => modal.classList.add("show"));
+}
+
+function closeDetailCard() {
+  const modal = document.getElementById("event-detail");
+  modal.classList.remove("show");
+  setTimeout(() => {
+    modal.style.display = "none";
+  }, 300);
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  const closeBtn = document.getElementById("close-detail");
+  const modal = document.getElementById("event-detail");
+  if (closeBtn) closeBtn.onclick = closeDetailCard;
+  if (modal) {
+    modal.addEventListener("click", (event) => {
+      if (event.target === modal) closeDetailCard();
+    });
+  }
+});
+
+// ---------- КАРТОЧКИ ----------
+function createCard(event, size = 2) {
+  const card = document.createElement("div");
+  card.className = "card";
+  card.onclick = () => openDetailCard(event);
+  if (size === 1) {
+    card.innerHTML = `
+      <img src="${event.Media || "https://via.placeholder.com/600x400"}" alt="">
+      <div class="overlay">
+        <h3>${event.Name}</h3>
+        <p>${event.Category || ""} • ${event.Date || ""}</p>
+      </div>`;
+  } else {
+    card.innerHTML = `
+      <img src="${event.Media || "https://via.placeholder.com/300x150"}" alt="">
+      <div class="info">
+        <div>
+          <h3>${event.Name}</h3>
+          <p>${event.Category || ""}${event.Subcategory ? " / " + event.Subcategory : ""}</p>
+          <p>${event.Date || ""}${event.Time ? " • " + event.Time : ""}</p>
+        </div>
+        <p style="font-weight:500;color:#007aff;">${event.Place || ""}</p>
+      </div>`;
+  }
+  return card;
+}
+
+function renderAll(events) {
+  const p1 = document.getElementById("priority1");
+  const p2 = document.getElementById("priority2");
+  const p3 = document.querySelector("#priority3 tbody");
+  if (!p1 || !p2 || !p3) return;
+
+  p1.innerHTML = "";
+  p2.innerHTML = "";
+  p3.innerHTML = "";
+
+  events.forEach((event) => {
+    const priority = Number(event.Priority) || 3;
+    if (priority === 1) {
+      p1.appendChild(createCard(event, 1));
+    } else if (priority === 2) {
+      p2.appendChild(createCard(event, 2));
+    } else {
+      const tr = document.createElement("tr");
+      tr.innerHTML = `<td>${event.Name}</td><td>${event.Category || ""}</td><td>${event.Date || ""}</td><td>${event.Time || ""}</td><td>${event.Place || ""}</td><td>${event.Cost || ""}</td>`;
+      tr.onclick = () => openDetailCard(event);
+      p3.appendChild(tr);
+    }
+  });
+
+  if (!p3.children.length) {
+    const emptyRow = document.createElement("tr");
+    emptyRow.innerHTML = '<td colspan="6" style="text-align:center;padding:24px;color:#666;">Ничего не найдено. Попробуйте изменить фильтры.</td>';
+    p3.appendChild(emptyRow);
+  }
+}
+
+function isFreeEvent(cost) {
+  if (!cost) return true;
+  const normalized = String(cost).toLowerCase();
+  if (!normalized.trim()) return true;
+  if (normalized.includes("беспл") || normalized.includes("free") || normalized.includes("donation")) {
+    return true;
+  }
+  const digits = normalized.replace(/[^0-9]/g, "");
+  if (!digits) return true;
+  return Number(digits) === 0;
+}
+
+function applyFilters() {
+  const searchTerm = filters.search.trim().toLowerCase();
+  filteredEvents = allEvents.filter((event) => {
+    const categoryValue = (event.Category || "").toLowerCase();
+    const combinedText = [event.Name, event.Place, event.Description, event.Category, event.Subcategory]
+      .filter(Boolean)
+      .join(" ")
+      .toLowerCase();
+
+    const matchesSearch = !searchTerm || combinedText.includes(searchTerm);
+    const matchesCategory = filters.category === "all" || categoryValue === filters.category;
+    const matchesPrice = filters.price === "all" || (filters.price === "free" ? isFreeEvent(event.Cost) : !isFreeEvent(event.Cost));
+
+    return matchesSearch && matchesCategory && matchesPrice;
+  });
+
+  renderAll(filteredEvents);
+
+  const mapModal = document.getElementById("map-modal");
+  if (mapModal && mapModal.style.display === "flex") {
+    const source = filteredEvents.length ? filteredEvents : allEvents;
+    initMap(source);
+    setTimeout(() => map && map.invalidateSize(), 200);
+  }
+}
+
+function setupFilters(events) {
+  const searchInput = document.getElementById("filter-search");
+  const categorySelect = document.getElementById("filter-category");
+  const priceSelect = document.getElementById("filter-price");
+  const resetButton = document.getElementById("filter-reset");
+
+  if (!searchInput || !categorySelect || !priceSelect || !resetButton) return;
+
+  const categories = Array.from(new Set(events
+    .map((event) => (event.Category || "").trim())
+    .filter(Boolean)))
+    .sort((a, b) => a.localeCompare(b, "ru", { sensitivity: "base" }));
+
+  categories.forEach((category) => {
+    const option = document.createElement("option");
+    option.value = category.toLowerCase();
+    option.textContent = category;
+    categorySelect.appendChild(option);
+  });
+
+  searchInput.addEventListener("input", (event) => {
+    filters.search = event.target.value;
+    applyFilters();
+  });
+
+  categorySelect.addEventListener("change", (event) => {
+    filters.category = event.target.value;
+    applyFilters();
+  });
+
+  priceSelect.addEventListener("change", (event) => {
+    filters.price = event.target.value;
+    applyFilters();
+  });
+
+  resetButton.addEventListener("click", () => {
+    filters.search = "";
+    filters.category = "all";
+    filters.price = "all";
+    searchInput.value = "";
+    categorySelect.value = "all";
+    priceSelect.value = "all";
+    applyFilters();
+  });
+}
+
+// ---------- ГЕОПАРСЕР ----------
+function parseCoordinatesFromText(text) {
+  if (!text) return null;
+  const regex = /(-?\d{1,2}\.\d+)[, ]+(-?\d{1,3}\.\d+)/;
+  const match = text.match(regex);
+  if (match) return { lat: parseFloat(match[1]), lon: parseFloat(match[2]) };
+  return null;
+}
+
+async function geocodeAddress(address) {
+  if (!address) return null;
+  const cacheKey = `geo_${address}`;
+  const cached = localStorage.getItem(cacheKey);
+  if (cached) return JSON.parse(cached);
+  const url = `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(address)}&limit=1`;
+  try {
+    const response = await fetch(url, { headers: { 'Accept-Language': 'ru' } });
+    if (!response.ok) return null;
+    const data = await response.json();
+    if (data[0]) {
+      const coords = { lat: parseFloat(data[0].lat), lon: parseFloat(data[0].lon) };
+      localStorage.setItem(cacheKey, JSON.stringify(coords));
+      return coords;
+    }
+  } catch (error) {
+    console.warn("Не удалось геокодировать адрес", address, error);
+  }
+  return null;
+}
+
+async function getEventCoordinates(event) {
+  if (event.Lat && event.Lon) {
+    return { lat: parseFloat(event.Lat), lon: parseFloat(event.Lon) };
+  }
+  const parsed = parseCoordinatesFromText(event.Place);
+  if (parsed) return parsed;
+  return geocodeAddress(event.Place);
+}
+
+// ---------- КАРТА ----------
+async function initMap(events) {
+  if (!map) {
+    map = L.map('map').setView([59.93, 30.33], 12);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { attribution: '&copy; OpenStreetMap' }).addTo(map);
+  }
+
+  map.eachLayer((layer) => {
+    if (layer instanceof L.Marker) {
+      map.removeLayer(layer);
+    }
+  });
+
+  for (const event of events) {
+    if (!event.Place) continue;
+    const coords = await getEventCoordinates(event);
+    if (coords) {
+      const marker = L.marker([coords.lat, coords.lon]).addTo(map);
+      marker.on("click", () => openDetailCard(event));
+    }
+  }
+}
+
+// ---------- ИНИЦИАЛИЗАЦИЯ ----------
+document.addEventListener("DOMContentLoaded", () => {
+  const openMap = document.getElementById("open-map");
+  const closeMap = document.getElementById("close-map");
+
+  if (openMap && closeMap) {
+    openMap.onclick = async (event) => {
+      event.preventDefault();
+      document.getElementById("map-modal").style.display = "flex";
+      const source = filteredEvents.length ? filteredEvents : allEvents;
+      await initMap(source);
+      setTimeout(() => map && map.invalidateSize(), 300);
+    };
+
+    closeMap.onclick = () => {
+      document.getElementById("map-modal").style.display = "none";
+    };
+  }
+
+  Papa.parse(csvUrl, {
+    download: true,
+    header: true,
+    skipEmptyLines: true,
+    complete: (results) => {
+      allEvents = (results.data || []).filter((event) => event.Name);
+      setupFilters(allEvents);
+      filteredEvents = [...allEvents];
+      renderAll(filteredEvents);
+    },
+    error: () => {
+      const tableBody = document.querySelector("#priority3 tbody");
+      if (tableBody) {
+        tableBody.innerHTML = '<tr><td colspan="6">Не удалось загрузить события. Попробуйте обновить страницу позже.</td></tr>';
+      }
+    }
+  });
+});

--- a/public/index.html
+++ b/public/index.html
@@ -115,9 +115,11 @@
     .priority-1 .card .overlay {
       position: absolute; bottom: 0; left: 0; right: 0;
       padding: 12px; background: linear-gradient(transparent, rgba(0,0,0,0.7));
+      display: flex; flex-direction: column; gap: 10px;
     }
+    .priority-1 .card .overlay-text { display: flex; flex-direction: column; gap: 4px; }
     .priority-1 .card h3 { margin: 0; font-size: 20px; font-weight: 600; }
-    .priority-1 .card p { margin: 4px 0 0; font-size: 14px; }
+    .priority-1 .card p { margin: 0; font-size: 14px; }
 
     .priority-2 .grid {
       display: flex; overflow-x: auto; scroll-snap-type: x mandatory;
@@ -137,10 +139,72 @@
     .priority-2 .card .info {
       padding: 10px 14px; display: flex; flex-direction: column;
       justify-content: space-between; height: calc(100% - 120px);
+      gap: 12px;
     }
+    .priority-2 .card .info-text { display: flex; flex-direction: column; gap: 6px; flex: 1; }
     .priority-2 .card h3 { margin: 0 0 6px; font-size: 15px; font-weight: 600; }
     .priority-2 .card p { margin: 0; font-size: 13px; color: #555; }
+    .priority-2 .card .info-place { margin-top: auto; font-weight: 600; color: #007aff; font-size: 13px; }
     .priority-2 .grid::-webkit-scrollbar { display: none; }
+
+    .card-actions {
+      display: flex;
+      gap: 8px;
+      flex-wrap: nowrap;
+    }
+    .card-actions button {
+      flex: 1;
+      border: none;
+      border-radius: 999px;
+      padding: 6px 10px;
+      font-size: 12px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+    }
+    .card-actions button:hover { transform: translateY(-1px); }
+    .card-actions button.is-active { background: #007aff; color: white; box-shadow: 0 6px 16px rgba(0, 122, 255, 0.35); }
+
+    .priority-1 .card-actions button {
+      background: rgba(255,255,255,0.85);
+      color: #111;
+    }
+    .priority-1 .card-actions button:hover { background: rgba(255,255,255,1); }
+    .priority-1 .card-actions button.is-active {
+      background: #ffb703;
+      color: #111;
+      box-shadow: 0 6px 16px rgba(255, 183, 3, 0.45);
+    }
+
+    .priority-2 .card-actions button {
+      background: rgba(0, 122, 255, 0.1);
+      color: #007aff;
+      border: 1px solid rgba(0, 122, 255, 0.25);
+    }
+    .priority-2 .card-actions button:hover {
+      background: rgba(0, 122, 255, 0.18);
+    }
+
+    .toast {
+      position: fixed;
+      left: 50%;
+      bottom: 32px;
+      transform: translate(-50%, 20px);
+      background: rgba(17, 17, 17, 0.9);
+      color: white;
+      padding: 12px 18px;
+      border-radius: 999px;
+      font-size: 14px;
+      font-weight: 500;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.3s ease, transform 0.3s ease;
+      z-index: 50;
+    }
+    .toast.show {
+      opacity: 1;
+      transform: translate(-50%, 0);
+    }
 
     table {
       width: 100%; border-collapse: collapse;

--- a/public/index.html
+++ b/public/index.html
@@ -1,127 +1,275 @@
 <!DOCTYPE html>
 <html lang="ru">
-  <head>
-    <meta charset="UTF-8" />
-    <title>События рядом</title>
-    <style>
-      body {
-        font-family: Arial, sans-serif;
-        padding: 20px;
-        background: #f4f4f4;
-      }
+<head>
+  <meta charset="UTF-8">
+  <title>События рядом</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
 
-      .card {
-        background: #fff;
-        padding: 15px;
-        margin-bottom: 15px;
-        border-radius: 8px;
-        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
-        cursor: pointer;
-      }
+  <style>
+    body { font-family: 'Inter', sans-serif; background: #f0f3f5; margin: 0; padding: 0; color: #111; }
+    h1 { text-align: center; font-weight: 600; margin: 20px 0 10px; }
 
-      .card img {
-        max-width: 100%;
-        border-radius: 5px;
-        margin-bottom: 10px;
-      }
+    .map-btn {
+      display: block;
+      width: fit-content;
+      margin: 20px auto 40px;
+      background: #007aff;
+      color: white;
+      padding: 12px 24px;
+      border-radius: 30px;
+      font-weight: 600;
+      cursor: pointer;
+      box-shadow: 0 4px 15px rgba(0,0,0,0.15);
+      text-decoration: none;
+      transition: background 0.2s;
+    }
+    .map-btn:hover { background: #005ad9; }
 
-      .card h2 {
-        margin: 0 0 5px 0;
-        font-size: 18px;
-      }
+    #map-modal {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,0.5);
+      backdrop-filter: blur(4px);
+      z-index: 20;
+      justify-content: center;
+      align-items: center;
+    }
+    #map-container {
+      width: 90%;
+      height: 80%;
+      max-width: 1000px;
+      border-radius: 16px;
+      overflow: hidden;
+      box-shadow: 0 8px 30px rgba(0,0,0,0.3);
+      position: relative;
+    }
+    #map { width: 100%; height: 100%; }
+    #close-map {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      background: rgba(255,255,255,0.9);
+      border: none;
+      border-radius: 8px;
+      padding: 6px 10px;
+      cursor: pointer;
+      font-weight: 600;
+    }
 
-      .card p {
-        margin: 0;
-        font-size: 14px;
-        color: #555;
-      }
+    .filters {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      justify-content: center;
+      margin: 10px 20px 30px;
+    }
+    .filters input,
+    .filters select,
+    .filters button {
+      padding: 10px 14px;
+      border-radius: 999px;
+      border: 1px solid rgba(0, 0, 0, 0.08);
+      background: white;
+      font-family: inherit;
+      font-size: 14px;
+      box-shadow: 0 6px 18px rgba(0, 0, 0, 0.06);
+      transition: box-shadow 0.2s ease, transform 0.2s ease;
+      cursor: pointer;
+    }
+    .filters input,
+    .filters select {
+      min-width: 180px;
+    }
+    .filters input { cursor: text; }
+    .filters input:focus,
+    .filters select:focus,
+    .filters button:hover {
+      outline: none;
+      box-shadow: 0 10px 24px rgba(0, 122, 255, 0.22);
+      transform: translateY(-1px);
+    }
+    .filters button {
+      background: #007aff;
+      color: white;
+      font-weight: 600;
+    }
 
-      #detail {
-        display: none;
-        background: #fff;
-        padding: 20px;
-        border-radius: 8px;
-      }
+    .section { padding: 0 20px 40px; }
+    .section h2 { margin: 0 0 16px; font-weight: 600; }
+    .grid { display: grid; gap: 20px; }
 
-      #back {
-        margin-top: 10px;
-        cursor: pointer;
-        color: blue;
-        text-decoration: underline;
-      }
-    </style>
-  </head>
-  <body>
-    <h1>События рядом</h1>
-    <div id="list"></div>
+    /* --- карточки --- */
+    .priority-1 .grid { grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); }
+    .priority-1 .card {
+      position: relative; height: 220px; overflow: hidden; border-radius: 18px;
+      color: white; box-shadow: 0 10px 25px rgba(0,0,0,0.2);
+      cursor: pointer; transition: transform 0.25s;
+    }
+    .priority-1 .card:hover { transform: translateY(-4px); }
+    .priority-1 .card img {
+      width: 100%; height: 180px; object-fit: cover; filter: brightness(75%);
+    }
+    .priority-1 .card .overlay {
+      position: absolute; bottom: 0; left: 0; right: 0;
+      padding: 12px; background: linear-gradient(transparent, rgba(0,0,0,0.7));
+    }
+    .priority-1 .card h3 { margin: 0; font-size: 20px; font-weight: 600; }
+    .priority-1 .card p { margin: 4px 0 0; font-size: 14px; }
 
-    <div id="detail">
+    .priority-2 .grid {
+      display: flex; overflow-x: auto; scroll-snap-type: x mandatory;
+      gap: 16px; padding-bottom: 10px; -webkit-overflow-scrolling: touch;
+    }
+    .priority-2 .card {
+      flex: 0 0 75%; max-width: 280px; min-width: 220px; height: 220px;
+      background: rgba(255,255,255,0.9); border-radius: 16px;
+      box-shadow: 0 6px 14px rgba(0,0,0,0.1);
+      scroll-snap-align: start; overflow: hidden; cursor: pointer;
+      transition: transform 0.2s;
+    }
+    .priority-2 .card:hover { transform: translateY(-4px); }
+    .priority-2 .card img {
+      width: 100%; height: 120px; object-fit: cover;
+    }
+    .priority-2 .card .info {
+      padding: 10px 14px; display: flex; flex-direction: column;
+      justify-content: space-between; height: calc(100% - 120px);
+    }
+    .priority-2 .card h3 { margin: 0 0 6px; font-size: 15px; font-weight: 600; }
+    .priority-2 .card p { margin: 0; font-size: 13px; color: #555; }
+    .priority-2 .grid::-webkit-scrollbar { display: none; }
+
+    table {
+      width: 100%; border-collapse: collapse;
+      background: rgba(255,255,255,0.8); backdrop-filter: blur(10px);
+      border-radius: 12px; overflow: hidden;
+    }
+    th, td {
+      padding: 10px 12px; text-align: left;
+      border-bottom: 1px solid #ddd; font-size: 14px;
+    }
+    th { background: rgba(240,240,240,0.8); font-weight: 600; }
+    tr:hover { background: rgba(240,240,240,0.5); }
+
+    /* --- модалка карточки --- */
+    #event-detail {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,0.4);
+      backdrop-filter: blur(8px);
+      z-index: 30;
+      justify-content: center;
+      align-items: center;
+      opacity: 0;
+      transition: opacity 0.3s ease;
+    }
+    #event-detail.show { display: flex; opacity: 1; }
+
+    #event-detail-content {
+      background: white;
+      border-radius: 16px;
+      padding: 20px;
+      max-width: 600px;
+      max-height: 80vh;
+      overflow-y: auto;
+      transform: translateY(40px);
+      opacity: 0;
+      transition: all 0.3s ease;
+    }
+    #event-detail.show #event-detail-content {
+      transform: translateY(0);
+      opacity: 1;
+    }
+
+    #detail-img { width: 100%; border-radius: 10px; margin-bottom: 10px; }
+    #close-detail {
+      background: #007aff; color: white; border: none;
+      padding: 8px 16px; border-radius: 8px;
+      cursor: pointer; font-weight: 600; float: right;
+    }
+
+    @media (max-width: 600px) {
+      .filters { margin: 20px 16px 28px; }
+      .filters input,
+      .filters select { flex: 1 1 100%; min-width: unset; }
+      .section { padding: 0 16px 32px; }
+      .priority-1 .grid { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+
+<body>
+  <h1>События рядом</h1>
+
+  <div class="filters">
+    <input type="search" id="filter-search" placeholder="Поиск по названию или месту">
+    <select id="filter-category">
+      <option value="all">Все категории</option>
+    </select>
+    <select id="filter-price">
+      <option value="all">Любая стоимость</option>
+      <option value="free">Только бесплатные</option>
+      <option value="paid">Платные события</option>
+    </select>
+    <button id="filter-reset" type="button">Сбросить фильтры</button>
+  </div>
+
+  <div class="section priority-1">
+    <h2>Главные события</h2>
+    <div class="grid" id="priority1"></div>
+  </div>
+
+  <a href="#" class="map-btn" id="open-map">🗺️ Показать на карте</a>
+
+  <div class="section priority-2">
+    <h2>Рекомендованные</h2>
+    <div class="grid" id="priority2"></div>
+  </div>
+
+  <div class="section priority-3">
+    <h2>Все события</h2>
+    <table id="priority3">
+      <thead>
+        <tr><th>Название</th><th>Категория</th><th>Дата</th><th>Время</th><th>Место</th><th>Цена</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+
+  <!-- модалка карты -->
+  <div id="map-modal">
+    <div id="map-container">
+      <div id="map"></div>
+      <button id="close-map">Закрыть ✕</button>
+    </div>
+  </div>
+
+  <!-- модалка карточки -->
+  <div id="event-detail">
+    <div id="event-detail-content">
+      <button id="close-detail">✕</button>
+      <img id="detail-img" src="" alt="">
       <h2 id="detail-title"></h2>
       <p><strong>Дата:</strong> <span id="detail-date"></span></p>
       <p><strong>Время:</strong> <span id="detail-time"></span></p>
       <p><strong>Место:</strong> <span id="detail-place"></span></p>
-      <p>
-        <strong>Категория:</strong>
-        <span id="detail-category"></span>
-        /
-        <span id="detail-subcategory"></span>
-      </p>
-      <p><strong>Тэги:</strong> <span id="detail-tags"></span></p>
+      <p><strong>Категория:</strong> <span id="detail-category"></span></p>
       <p><strong>Цена:</strong> <span id="detail-cost"></span></p>
+      <button id="detail-map-btn"
+        style="background:#1e90ff;color:white;border:none;padding:10px 18px;
+               border-radius:8px;cursor:pointer;font-weight:600;margin:10px 0;">
+        🗺️ Открыть на карте
+      </button>
       <p id="detail-desc"></p>
-      <img id="detail-img" src="" alt="" />
-      <div id="back">Назад к списку</div>
     </div>
+  </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/tabletop@1.6.0/src/tabletop.min.js"></script>
-    <script>
-      const spreadsheetID = '1hIEkmJqEPJ2thixooVviNQL0j1qeLiA00Af8warNT3g';
-
-      function showList(data) {
-        const list = document.getElementById('list');
-        list.innerHTML = '';
-        data.forEach((event) => {
-          const card = document.createElement('div');
-          card.className = 'card';
-          card.innerHTML = `
-          <img src="${event.Media}" alt="${event.Name}">
-          <h2>${event.Name}</h2>
-          <p>${event.Date} ${event.Time} — ${event.Place}</p>
-          <p>Категория: ${event.Category} / ${event.Subcategory}</p>
-        `;
-          card.onclick = () => showDetail(event);
-          list.appendChild(card);
-        });
-      }
-
-      function showDetail(event) {
-        document.getElementById('list').style.display = 'none';
-        document.getElementById('detail').style.display = 'block';
-
-        document.getElementById('detail-title').textContent = event.Name;
-        document.getElementById('detail-date').textContent = event.Date;
-        document.getElementById('detail-time').textContent = event.Time;
-        document.getElementById('detail-place').textContent = event.Place;
-        document.getElementById('detail-category').textContent = event.Category;
-        document.getElementById('detail-subcategory').textContent = event.Subcategory;
-        document.getElementById('detail-tags').textContent = event.Tags;
-        document.getElementById('detail-cost').textContent = event.cost;
-        document.getElementById('detail-desc').textContent = event.Description;
-        document.getElementById('detail-img').src = event.Media;
-      }
-
-      document.getElementById('back').onclick = () => {
-        document.getElementById('detail').style.display = 'none';
-        document.getElementById('list').style.display = 'block';
-      };
-
-      Tabletop.init({
-        key: spreadsheetID,
-        callback(data) {
-          showList(data);
-        },
-        simpleSheet: true,
-      });
-    </script>
-  </body>
+  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
+  <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
+  <script src="events.js"></script>
+</body>
 </html>


### PR DESCRIPTION
## Summary
- add search, category, and price filters with a reset option to the event listing page
- populate filters from the sheet data, reuse filtered results across cards/table/map, and show an empty-state message when nothing matches

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e61f3962f48320ae6353fe0e128b34